### PR TITLE
removed nodeid

### DIFF
--- a/events/es-threshold.events.xml
+++ b/events/es-threshold.events.xml
@@ -14,7 +14,7 @@
         &lt;/table></descr>
       <logmsg dest="logndisplay">Elasticsearch warning: %parm[description]%</logmsg>
       <severity>Warning</severity>
-      <alarm-data reduction-key="%uei%:%nodeid%:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" alarm-type="1" auto-clean="false"/>
+      <alarm-data reduction-key="%uei%:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" alarm-type="1" auto-clean="false"/>
    </event>
    <event>
       <uei>uei.opennms.org/threshold/elasticsearch/warning/rearmed</uei>
@@ -30,6 +30,6 @@
         &lt;/table></descr>
       <logmsg dest="logndisplay">RESOLVED: Elasticsearch warning: %parm[description]%.</logmsg>
       <severity>Normal</severity>
-      <alarm-data reduction-key="%uei%:%nodeid%:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" alarm-type="2" clear-key="uei.opennms.org/threshold/elasticsearch/warning/exceeded:%nodeid%:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" auto-clean="false"/>
+      <alarm-data reduction-key="%uei%:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" alarm-type="2" clear-key="uei.opennms.org/threshold/elasticsearch/warning/exceeded:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" auto-clean="false"/>
    </event>
 </events>


### PR DESCRIPTION
`nodeId` is not handy in the alarm key. Since those health cluster metrics are identical on all ES nodes, the alarm was raised 1-n. Now the reduction key is grouping the alarm to one node.